### PR TITLE
Update LD_LIBRARY_PATH in R2022b Dockerfile

### DIFF
--- a/R2022b/Dockerfile
+++ b/R2022b/Dockerfile
@@ -44,6 +44,6 @@ RUN mkdir /mcr-install && \
     rm -rf mcr-install  
 
 # Configure environment variables for MCR  
-ENV LD_LIBRARY_PATH /opt/mcr/v913/runtime/glnxa64:/opt/mcr/v913/bin/glnxa64:/opt/mcr/v913/sys/os/glnxa64:/opt/mcr/v913/extern/bin/glnxa64  
+ENV LD_LIBRARY_PATH /opt/mcr/R2022b/runtime/glnxa64:/opt/mcr/R2022b/bin/glnxa64:/opt/mcr/R2022b/sys/os/glnxa64:/opt/mcr/R2022b/extern/bin/glnxa64  
 
 ENV XAPPLRESDIR /etc/X11/app-defaults  


### PR DESCRIPTION
From Matlab Runtime version R2022b the runtime is no more installed in a folder identified by the version number (i.e. v913) but by the name of the Matlab release name (i.e. R2022b). 

See Release notes [here ](https://it.mathworks.com/help/compiler/release-notes.html?rntext=&startrelease=R2020b&endrelease=R2023b&groupby=release&sortby=descending&searchHighlight=) in the R2022b section under _"MATLAB Runtime: Installation path updated to use MATLAB release name"_